### PR TITLE
support FreeBSD without a warning and fix a typo in the warning message

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,11 +65,12 @@ switch (os.platform()) {
 
     case 'darwin':
     case 'sunos':
+    case 'freebsd':
         _getMacAddress = require('./lib/unix.js');
         break;
         
     default:
-        console.warn("node-macaddress: Unkown os.platform(), defaulting to `unix'.");
+        console.warn("node-macaddress: Unknown os.platform(), defaulting to `unix'.");
         _getMacAddress = require('./lib/unix.js');
         break;
 


### PR DESCRIPTION
This small patch adds support for FreeBSD without the nasty warning and it also fixes a typo in the warning message itself.