### PR TITLE
Correct two typos

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ switch (os.platform()) {
         break;
         
     default:
-        console.warn("node-macaddress: Unkown os.platform(), defaulting to `unix'.");
+        console.warn("node-macaddress: Unknown os.platform(), defaulting to 'unix'.");
         _getMacAddress = require('./lib/unix.js');
         break;
 


### PR DESCRIPTION
Every time I run a build on an operating system this library doesn't recognize, I see these two typos.