### PR TITLE
Add support promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,19 @@ switch (os.platform()) {
 }
 
 lib.one = function (iface, callback) {
+    if (!iface && !callback) {
+        return new Promise(function (resolve, reject) {
+            lib.one(function (err, mac) {
+                if (err) {
+                    reject(new Error(err));
+                    return;
+                }
+
+                resolve(mac);
+            });
+        });
+    }
+
     if (typeof iface === 'function') {
         callback = iface;
 
@@ -126,6 +139,18 @@ lib.one = function (iface, callback) {
 };
 
 lib.all = function (callback) {
+    if (!callback) {
+        return new Promise(function (resolve, reject) {
+            lib.all(function (err, all) {
+                if (err) {
+                    reject(new Error(err));
+                    return;
+                }
+
+                resolve(all);
+            });
+        });
+    }
 
     var ifaces = lib.networkInterfaces();
     var resolve = {};


### PR DESCRIPTION
Addresses #24 

Sorry, too late.
one, all function support promise.

## API

```ts
.one(iface, callback) → string
.one(callback)        → string
.one()                → Promise<mac: string>

.all(callback)        → { iface: { type: address } }
.all()                → Promise<Array<{ iface: { type: address } }>>
```

## Example

```ts
const macaddress = require('macaddress');

macaddress.one().then(mac => console.log(mac));
// 00:00:00:00:00:00

macaddress.all().then(all => console.log(all));
/*
{
  "en0": {
    "ipv6": "fe80::cae0:ebff:fe14:1da9",
    "ipv4": "192.168.178.20",
    "mac": "ab:42:de:13:ef:37"
  },
  "awdl0": {
    "ipv6": "fe80::58b9:daff:fea9:23a9",
    "mac": "ab:cd:ef:34:12:56"
  }
}
*/
```
