### PR TITLE
fix(): update typescript definitions with Promise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ the host system (see `API + Examples` below).
 + also features a sane replacement for `os.networkInterfaces()`
   (see `API + Examples` below).
 + works with stoneage node versions ≥ v0.8 (...)
+* Promise support
 
 Usage
 -----
@@ -37,7 +38,9 @@ API + Examples
 --------------
 
     (async)  .one(iface, callback) → string
+    (async)  .one(iface)           → Promise<string>
     (async)  .one(callback)        → string
+    (async)  .all()                → Promise<{ iface: { type: address } }>
     (async)  .all(callback)        → { iface: { type: address } }
     (sync)   .networkInterfaces()  → { iface: { type: address } }
 
@@ -58,6 +61,14 @@ macaddress.one(function (err, mac) {
 });
 ```
 
+or using Promise
+
+```JavaScript
+macaddress.one.then(function (mac) {
+  console.log("Mac address for this host: %s", mac);  
+});
+```
+
 ```
 → Mac address for this host: ab:42:de:13:ef:37
 ```
@@ -66,6 +77,13 @@ macaddress.one(function (err, mac) {
 
 ```JavaScript
 macaddress.one('awdl0', function (err, mac) {
+  console.log("Mac address for awdl0: %s", mac);  
+});
+```
+or using Promise
+
+```JavaScript
+macaddress.one('awdl0').then(function (mac) {
   console.log("Mac address for awdl0: %s", mac);  
 });
 ```
@@ -82,6 +100,13 @@ Retrieves the MAC addresses for all non-internal interfaces.
 
 ```JavaScript
 macaddress.all(function (err, all) {
+  console.log(JSON.stringify(all, null, 2));
+});
+```
+or using Promise
+
+```JavaScript
+macaddress.all().then(function (all) {
   console.log(JSON.stringify(all, null, 2));
 });
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,9 +3,12 @@ declare module 'macaddress' {
 
   export type MacAddressOneCallback = (err: any, mac: string) => void;
 
-  export function one(ifaceOrCallback: string | MacAddressOneCallback, callback?: MacAddressOneCallback): void;
+  export function one(callback: MacAddressOneCallback): void;
+  export function one(iface?: string): Promise<string>;
+  export function one(iface: string, callback: MacAddressOneCallback): void;
 
   export function all(callback: MacAddresCallback): void;
+  export function all(): Promise<any>;
 
   export function networkInterfaces(): any;
 }


### PR DESCRIPTION
https://github.com/scravy/node-macaddress/pull/26 introduced Promise support but the typescript definitions were not updated (which means it can't be used in typescript).

Also updated the docs.