### PR TITLE
fix(): macaddress.one() should return a Promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,9 +90,9 @@ switch (os.platform()) {
 }
 
 lib.one = function (iface, callback) {
-    if (!iface && !callback) {
+    if (!callback && typeof iface !== 'function') {
         return new Promise(function (resolve, reject) {
-            lib.one(function (err, mac) {
+            lib.one(iface, function (err, mac) {
                 if (err) {
                     reject(new Error(err));
                     return;


### PR DESCRIPTION
The implementation of Promise support was incorrect. I recommend **adding unit tests** because [this PR](https://github.com/scravy/node-macaddress/pull/26):
*  broke the TypeScript support ([fixed here](https://github.com/scravy/node-macaddress/pull/30))
* was incorrectly implemented
* the app will break for previous versions of node, because `Promise` does not exist

`.one()` should return a Promise
`.one('eth0)`, should return a Promise
`.one(callback)` should return void and use the callback
`.one('eth0', callback)` should return void and use the callback