### PR TITLE
macOS Sequoia+ Private Wifi Address Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ lib.all = function (callback) {
     var ifaces = lib.networkInterfaces();
     var resolve = {};
     Object.keys(ifaces).forEach(function (iface) {
-        if (!ifaces[iface].mac) {
+        if (!ifaces[iface].mac || (os.platform() === 'darwin' && os.release().split('.')[0] >= 24)) {
             resolve[iface] = lib.getMacAddress.bind(null, iface);
         }
     });

--- a/index.js
+++ b/index.js
@@ -52,6 +52,9 @@ lib.one = function () {
         args.push(name);
         var score = 0;
         var iface = ifaces[name];
+        if (os.platform() === 'darwin' && os.release().split('.')[0] >= 24) {
+            iface.mac = lib.getMacAddress.bind(null, iface);
+        }
         if (typeof iface.mac === "string" && iface.mac !== "00:00:00:00:00:00") {
             addresses[name] = iface.mac;
             if (iface.ipv4) {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 
 var util = require("./lib/util.js");
 var lib = {};
+var os = require("os");
 
 lib.getMacAddress     = require("./lib/getmacaddress.js");
 lib.getAllInterfaces  = require("./lib/getallinterfaces.js");

--- a/lib/getmacaddress.js
+++ b/lib/getmacaddress.js
@@ -15,6 +15,8 @@ switch (os.platform()) {
         break;
 
     case 'darwin':
+        _getMacAddress = require('./platform/getmacaddress_darwin.js');
+        break;
     case 'sunos':
     case 'freebsd':
         _getMacAddress = require('./platform/getmacaddress_unix.js');

--- a/lib/getmacaddress.js
+++ b/lib/getmacaddress.js
@@ -15,7 +15,11 @@ switch (os.platform()) {
         break;
 
     case 'darwin':
-        _getMacAddress = require('./platform/getmacaddress_darwin.js');
+        if (os.release().split('.')[0] >= 24){
+            _getMacAddress = require('./platform/getmacaddress_darwin.js');
+        } else {
+            _getMacAddress = require('./platform/getmacaddress_unix.js');
+        }
         break;
     case 'sunos':
     case 'freebsd':

--- a/lib/networkinterfaces.js
+++ b/lib/networkinterfaces.js
@@ -1,5 +1,9 @@
 var os = require('os');
 
+var lib = {};
+
+lib.getMacAddress = require("./getmacaddress.js");
+
 // Retrieves all interfaces that do feature some non-internal address.
 // This function does NOT employ caching as to reflect the current state
 // of the machine accurately.
@@ -30,7 +34,12 @@ module.exports = function () {
                 addresses[family] = address.address;
                 hasAddresses = true;
                 if (address.mac && address.mac !== '00:00:00:00:00:00') {
-                    addresses.mac = address.mac;
+                    if (os.platform() === 'darwin' && os.release().split('.')[0] >= 24) {
+                        addresses.mac = lib.getMacAddress.bind(null, iface);
+                    }
+                    else{
+                        addresses.mac = address.mac;
+                    }
                 }
             }
         });

--- a/lib/platform/getmacaddress_darwin.js
+++ b/lib/platform/getmacaddress_darwin.js
@@ -1,0 +1,17 @@
+/* jshint node: true */
+var execFile = require('child_process').execFile;
+
+module.exports = function (iface, callback) {
+    execFile("/usr/sbin/networksetup", ["-getmacaddress", iface], function (err, out) {
+        if (err) {
+            callback(err, null);
+            return;
+        }
+        var match = /[a-f0-9]{2}(:[a-f0-9]{2}){5}/.exec(out.toLowerCase());
+        if (!match) {
+            callback("did not find a mac address", null);
+            return;
+        }
+        callback(null, match[0].toLowerCase());
+    });
+};


### PR DESCRIPTION
Changes
* Fixed MAC address resolution for macOS Sequoia+ to correctly handle private Wi-Fi addresses by introducing a platform-specific check for macOS with release version 24 or higher.
* Added a new module for macOS (`getmacaddress_darwin.js`) to resolve MAC addresses using the `networksetup` utility.

Affected Files
* `index.js`
* `lib/getmacaddress.js`
* `lib/platform/getmacaddress_darwin.js`