### PR TITLE
fix: error instance check in promisify function

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -37,7 +37,7 @@ lib.promisify = function (func) {
     return new Promise(function (resolve, reject) {
         func(function (err, data) {
             if (err) {
-                if (!err instanceof Error) {
+                if (!(err instanceof Error)) {
                     err = new Error(err);
                 }
                 reject(err);


### PR DESCRIPTION
`macaddress` is a dependency coming in transitively in my project. I was running webpack / terser and encountered a warning for the `instanceof` check. Looking at the code, this seems like a real bug.

I adapted the `instanceof` check, please have a look.